### PR TITLE
Fix routing cost direction and ensure no-path test coverage

### DIFF
--- a/src/Core.Routing/CostFunction.cs
+++ b/src/Core.Routing/CostFunction.cs
@@ -56,18 +56,27 @@ namespace KRouter.Core.Routing
             }
 
             // Preferred direction (horizontal on even layers, vertical on odd)
+            // Instead of rewarding movement in the preferred direction by reducing
+            // cost (which could lead to negative costs), we only add a penalty when
+            // the movement is primarily in the non-preferred direction. This keeps
+            // the base distance cost intact while still biasing the search toward
+            // preferred orientations.
             if (from.Layer == to.Layer)
             {
                 var dx = Math.Abs(to.Position.X - from.Position.X);
                 var dy = Math.Abs(to.Position.Y - from.Position.Y);
-                
-                if (from.LayerIndex % 2 == 0 && dx > dy)
+
+                // Even layers favour horizontal movement. Penalize vertical-dominant
+                // moves on these layers.
+                if (from.LayerIndex % 2 == 0 && dy > dx)
                 {
-                    cost -= PreferredDirectionWeight * distance;
+                    cost += PreferredDirectionWeight * distance;
                 }
-                else if (from.LayerIndex % 2 == 1 && dy > dx)
+                // Odd layers favour vertical movement. Penalize horizontal-dominant
+                // moves on these layers.
+                else if (from.LayerIndex % 2 == 1 && dx > dy)
                 {
-                    cost -= PreferredDirectionWeight * distance;
+                    cost += PreferredDirectionWeight * distance;
                 }
             }
 

--- a/tests/Core.Routing.Tests/RoutingTests.cs
+++ b/tests/Core.Routing.Tests/RoutingTests.cs
@@ -63,10 +63,14 @@ namespace KRouter.Tests.Core.Routing
             var router = new AStarRouter();
             var costFunction = new CostFunction();
 
-            for (long y = -1_000_000; y <= 1_000_000; y += 100_000)
-            {
-                graph.AddObstacle(new Point2D(500_000, y), "F.Cu");
-            }
+            // Create a solid vertical wall across the entire routing area so that
+            // no path from start to end exists on the given layer. Using a line
+            // ensures every grid point along the wall is marked as an obstacle.
+            var blockingLine = new Line2D(
+                new Point2D(500_000, 0),
+                new Point2D(500_000, 10_000_000)
+            );
+            graph.AddObstacleLine(blockingLine, "F.Cu");
 
             var start = new RoutingNode(new Point2D(0, 0), "F.Cu", 0);
             var end = new RoutingNode(new Point2D(1_000_000, 0), "F.Cu", 0);


### PR DESCRIPTION
## Summary
- Avoid negative routing costs by penalising only non-preferred direction moves
- Strengthen `AStarRouter_NoPath_ReturnsNull` test by adding a solid obstacle wall

## Testing
- `dotnet test tests/Core.Routing.Tests/Core.Routing.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68a0bbf41f5c832caa8276efa864828e