### PR TITLE
Fix SES generator to use routing section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+- Fix SES generator to emit KiCad-compatible `routing` section

--- a/KRouter.sln
+++ b/KRouter.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Routing.Tests", "tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cli", "src\Cli\Cli.csproj", "{BBEDFD07-A131-44FC-9CF3-5A2E295146E7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cli.Tests", "tests\Cli.Tests\Cli.Tests.csproj", "{D376636E-D81F-4CA7-A998-E2E430FDCC9E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,17 +87,30 @@ Global
 		{BBEDFD07-A131-44FC-9CF3-5A2E295146E7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BBEDFD07-A131-44FC-9CF3-5A2E295146E7}.Release|x64.ActiveCfg = Release|Any CPU
 		{BBEDFD07-A131-44FC-9CF3-5A2E295146E7}.Release|x64.Build.0 = Release|Any CPU
-		{BBEDFD07-A131-44FC-9CF3-5A2E295146E7}.Release|x86.ActiveCfg = Release|Any CPU
-		{BBEDFD07-A131-44FC-9CF3-5A2E295146E7}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {BBEDFD07-A131-44FC-9CF3-5A2E295146E7}.Release|x86.ActiveCfg = Release|Any CPU
+                {BBEDFD07-A131-44FC-9CF3-5A2E295146E7}.Release|x86.Build.0 = Release|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Debug|x64.Build.0 = Debug|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Debug|x86.Build.0 = Debug|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Release|x64.ActiveCfg = Release|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Release|x64.Build.0 = Release|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Release|x86.ActiveCfg = Release|Any CPU
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0608291A-EF84-4200-8EF9-C4CFD90FB7C2} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{7B8BA576-7E63-4FB3-B3D1-2F65718CE05A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
-		{BCDBB644-A125-4B3F-A07B-616D9E5E592A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
-		{D253DB8B-16CE-482A-A990-DA6AAA44FE3A} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
-		{BBEDFD07-A131-44FC-9CF3-5A2E295146E7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
-	EndGlobalSection
+                {BCDBB644-A125-4B3F-A07B-616D9E5E592A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+                {D253DB8B-16CE-482A-A990-DA6AAA44FE3A} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+                {BBEDFD07-A131-44FC-9CF3-5A2E295146E7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+                {D376636E-D81F-4CA7-A998-E2E430FDCC9E} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+        EndGlobalSection
 EndGlobal

--- a/src/Cli/AssemblyInfo.cs
+++ b/src/Cli/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Cli.Tests")]

--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -9,7 +9,7 @@ namespace KRouter.Cli
     /// Entry point for the KRouter command-line interface.
     /// Provides minimal routing commands for KiCad integration.
     /// </summary>
-    class Program
+    internal class Program
     {
         /// <summary>
         /// Main entry point. Configures available commands and options.
@@ -150,8 +150,8 @@ For more information, visit: https://github.com/arnisz/krouter
                 Console.WriteLine();
                 Console.WriteLine();
 
-                // Generate simple SES output
-                var sesContent = GenerateSimpleSES(input.Name.Replace(".dsn", ""), netCount);
+                // Generate KiCad-compatible SES output
+                var sesContent = GenerateKiCadCompatibleSES(input.Name.Replace(".dsn", ""), netCount);
                 await File.WriteAllTextAsync(output.FullName, sesContent);
 
                 // Report results
@@ -195,51 +195,43 @@ For more information, visit: https://github.com/arnisz/krouter
         }
 
         /// <summary>
-        /// Generates a minimal SES file for demonstration.
+        /// Generates a KiCad-compatible SES file for demonstration.
         /// </summary>
         /// <param name="designName">Design name.</param>
         /// <param name="netCount">Number of nets.</param>
         /// <returns>SES file content.</returns>
-        private static string GenerateSimpleSES(string designName, int netCount)
+        internal static string GenerateKiCadCompatibleSES(string designName, int netCount)
         {
             return $@"(session ""{designName}.ses""
   (base_design ""{designName}.dsn"")
   (placement
     (resolution mm 1000000)
   )
-  (was_is
-    (routes
-      (resolution mm 1000000)
-      (parser
-        (host_cad ""KRouter"")
-        (host_version ""1.0.0"")
+  (routing
+    (resolution mm 1000000)
+    (parser
+      (host_cad ""KRouter"")
+      (host_version ""1.0.0"")
+    )
+    (library
+      (padstack ""Via[0-1]_600:300_um""
+        (shape (circle F.Cu 600 0 0))
+        (shape (circle B.Cu 600 0 0))
+        (attach off)
       )
-      (library_out
-        (padstack ""Via[0-1]_600:300_um""
-          (shape (circle F.Cu 600 0 0))
-          (shape (circle B.Cu 600 0 0))
-          (attach off)
+    )
+    (network
+      (net ""GND""
+        (wire
+          (path F.Cu 250
+            50000 75000
+            80000 75000
+          )
+          (type protect)
         )
       )
-      (network_out
-        (net ""GND""
-          (wire
-            (path F.Cu 250
-              50000 75000
-              80000 75000
-            )
-            (type protect)
-          )
-        )
-        (net ""VCC""
-          (wire
-            (path F.Cu 250
-              120000 75000
-              100000 75000
-            )
-            (type protect)
-          )
-        )
+      (via ""Via[0-1]_600:300_um"" 100000 75000
+        (net ""VCC"")
       )
     )
   )

--- a/tests/Cli.Tests/Cli.Tests.csproj
+++ b/tests/Cli.Tests/Cli.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Cli/Cli.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Cli.Tests/SesGenerationTests.cs
+++ b/tests/Cli.Tests/SesGenerationTests.cs
@@ -1,0 +1,19 @@
+using KRouter.Cli;
+using Xunit;
+
+namespace KRouter.Tests.Cli
+{
+    public class SesGenerationTests
+    {
+        [Fact]
+        public void GenerateKiCadCompatibleSES_UsesRoutingSection()
+        {
+            var ses = Program.GenerateKiCadCompatibleSES("design", 2);
+            Assert.Contains("(routing", ses);
+            Assert.DoesNotContain("(was_is", ses);
+            Assert.DoesNotContain("(routes", ses);
+            Assert.Contains("(library", ses);
+            Assert.Contains("(network", ses);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- output SES using `routing` tree for KiCad compatibility
- add regression test for SES generator

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a19fa4e868832c944de1fc87138c87