### PR TITLE
Implement basic DSN parsing and SES output

### DIFF
--- a/src/Cli/DsnParser.cs
+++ b/src/Cli/DsnParser.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using KRouter.Core.Geometry;
+
+namespace KRouter.Cli
+{
+    /// <summary>
+    /// Basic parser for a minimal subset of the Specctra DSN format.
+    /// Extracts resolution, layers, board boundary and net pin positions.
+    /// </summary>
+    public class DsnParser
+    {
+        /// <summary>Parses DSN content and returns structured data.</summary>
+        /// <param name="dsnContent">Raw DSN file content.</param>
+        /// <returns>Parsed DSN information.</returns>
+        public DsnData Parse(string dsnContent)
+        {
+            var resolution = GetResolution(dsnContent);
+            var layers = ParseLayers(dsnContent).ToList();
+            var placements = ParsePlacements(dsnContent);
+            var library = ParseLibrary(dsnContent);
+            var nets = ParseNets(dsnContent, placements, library, resolution).ToList();
+            var boundary = ParseBoundary(dsnContent, resolution);
+            return new DsnData
+            {
+                Resolution = resolution,
+                Layers = layers,
+                Boundary = boundary,
+                Nets = nets
+            };
+        }
+
+        private static long GetResolution(string dsn)
+        {
+            var m = Regex.Match(dsn, "\\(resolution\\s+\\w+\\s+(\\d+)\\)");
+            if (m.Success && long.TryParse(m.Groups[1].Value, out var r))
+                return r;
+            return 1;
+        }
+
+        private static IEnumerable<string> ParseLayers(string dsn)
+        {
+            var matches = Regex.Matches(dsn, "\\(layer\\s+([^\\s\\)]+)");
+            foreach (Match m in matches)
+                yield return m.Groups[1].Value;
+        }
+
+        private static Dictionary<string, ComponentPlacement> ParsePlacements(string dsn)
+        {
+            var result = new Dictionary<string, ComponentPlacement>();
+            var lines = dsn.Split('\n');
+            bool inPlacement = false;
+            int depth = 0;
+            string? currentImage = null;
+            foreach (var raw in lines)
+            {
+                var line = raw.Trim();
+                if (!inPlacement)
+                {
+                    if (line.StartsWith("(placement"))
+                    {
+                        inPlacement = true; depth = 1;
+                    }
+                    continue;
+                }
+                depth += line.Count(c => c == '(') - line.Count(c => c == ')');
+                if (line.StartsWith("(component"))
+                {
+                    var m = Regex.Match(line, "^\\(component\\s+\"?([^\\\"]+)\"?");
+                    if (m.Success)
+                        currentImage = m.Groups[1].Value;
+                }
+                else if (line.StartsWith("(place") && currentImage != null)
+                {
+                    var m = Regex.Match(line, "^\\(place\\s+(\\S+)\\s+([-+]?\\d*\\.?\\d+)\\s+([-+]?\\d*\\.?\\d+)\\s+(front|back)\\s+([-+]?\\d*\\.?\\d+)");
+                    if (m.Success)
+                    {
+                        var reference = m.Groups[1].Value;
+                        var x = double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture);
+                        var y = double.Parse(m.Groups[3].Value, CultureInfo.InvariantCulture);
+                        var rot = double.Parse(m.Groups[5].Value, CultureInfo.InvariantCulture);
+                        result[reference] = new ComponentPlacement(currentImage, x, y, rot);
+                    }
+                }
+                if (depth <= 0)
+                    break;
+            }
+            return result;
+        }
+
+        private static Dictionary<string, Dictionary<string, (double X, double Y)>> ParseLibrary(string dsn)
+        {
+            var result = new Dictionary<string, Dictionary<string, (double X, double Y)>>();
+            var lines = dsn.Split('\n');
+            bool inLibrary = false;
+            int depth = 0;
+            string? currentImage = null;
+            int imageDepth = 0;
+            foreach (var raw in lines)
+            {
+                var line = raw.Trim();
+                if (!inLibrary)
+                {
+                    if (line.StartsWith("(library"))
+                    {
+                        inLibrary = true; depth = 1;
+                    }
+                    continue;
+                }
+                depth += line.Count(c => c == '(') - line.Count(c => c == ')');
+                if (line.StartsWith("(image"))
+                {
+                    var m = Regex.Match(line, "^\\(image\\s+\"?([^\\\"]+)\"?");
+                    if (m.Success)
+                    {
+                        currentImage = m.Groups[1].Value;
+                        result[currentImage] = new Dictionary<string, (double, double)>();
+                        imageDepth = 1;
+                    }
+                    continue;
+                }
+                if (currentImage != null)
+                {
+                    imageDepth += line.Count(c => c == '(') - line.Count(c => c == ')');
+                    if (line.StartsWith("(pin"))
+                    {
+                        var m = Regex.Match(line, "\\(pin[^\\)]*\\s(\\S+)\\s([-+]?\\d*\\.?\\d+)\\s([-+]?\\d*\\.?\\d+)\\)");
+                        if (m.Success)
+                        {
+                            var pad = m.Groups[1].Value;
+                            var x = double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture);
+                            var y = double.Parse(m.Groups[3].Value, CultureInfo.InvariantCulture);
+                            result[currentImage][pad] = (x, y);
+                        }
+                    }
+                    if (imageDepth <= 0)
+                        currentImage = null;
+                }
+                if (depth <= 0)
+                    break;
+            }
+            return result;
+        }
+
+        private static IEnumerable<DsnNet> ParseNets(string dsn,
+            Dictionary<string, ComponentPlacement> placements,
+            Dictionary<string, Dictionary<string, (double X, double Y)>> library,
+            long resolution)
+        {
+            var matches = Regex.Matches(dsn, "\\(net\\s+\\\"?([^\\\"\\s]+)\\\"?\\s*\\(pins\\s+([^\\)]+)\\)\\s*\\)", RegexOptions.Singleline);
+            foreach (Match m in matches)
+            {
+                var net = new DsnNet { Name = m.Groups[1].Value };
+                var pins = m.Groups[2].Value.Trim()
+                    .Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var p in pins)
+                {
+                    var parts = p.Split('-');
+                    if (parts.Length != 2) continue;
+                    if (!placements.TryGetValue(parts[0], out var placement)) continue;
+                    if (!library.TryGetValue(placement.Image, out var pinsDict)) continue;
+                    if (!pinsDict.TryGetValue(parts[1], out var rel)) continue;
+                    var (absX, absY) = Transform(rel.X, rel.Y, placement);
+                    var scaledX = Scale(absX + placement.X, resolution);
+                    var scaledY = Scale(absY + placement.Y, resolution);
+                    net.Pins.Add(new Point2D(scaledX, scaledY));
+                }
+                yield return net;
+            }
+        }
+
+        private static (double X, double Y) Transform(double x, double y, ComponentPlacement placement)
+        {
+            var angle = placement.Rotation * Math.PI / 180.0;
+            var cos = Math.Cos(angle);
+            var sin = Math.Sin(angle);
+            var rx = x * cos - y * sin;
+            var ry = x * sin + y * cos;
+            return (rx, ry);
+        }
+
+        private static BoundingBox ParseBoundary(string dsn, long resolution)
+        {
+            var m = Regex.Match(dsn, "\\(boundary\\s*\\(path\\s+pcb\\s+\\d+\\s+([^\\)]+)\\)\\)", RegexOptions.Singleline);
+            if (!m.Success)
+                return new BoundingBox(new Point2D(0, 0), new Point2D(0, 0));
+            var nums = Regex.Matches(m.Groups[1].Value, "[-+]?\\d*\\.?\\d+");
+            double minX = double.MaxValue, minY = double.MaxValue;
+            double maxX = double.MinValue, maxY = double.MinValue;
+            bool isX = true;
+            foreach (Match num in nums)
+            {
+                var v = double.Parse(num.Value, CultureInfo.InvariantCulture);
+                if (isX)
+                {
+                    minX = Math.Min(minX, v); maxX = Math.Max(maxX, v);
+                }
+                else
+                {
+                    minY = Math.Min(minY, v); maxY = Math.Max(maxY, v);
+                }
+                isX = !isX;
+            }
+            return new BoundingBox(
+                new Point2D(Scale(minX, resolution), Scale(minY, resolution)),
+                new Point2D(Scale(maxX, resolution), Scale(maxY, resolution)));
+        }
+
+        private static long Scale(double value, long resolution)
+        {
+            return (long)Math.Round(value * resolution);
+        }
+    }
+
+    /// <summary>Represents parsed DSN information.</summary>
+    public class DsnData
+    {
+        /// <summary>Database resolution (units per micron).</summary>
+        public long Resolution { get; set; }
+        /// <summary>All available layers.</summary>
+        public List<string> Layers { get; set; } = new();
+        /// <summary>Board boundary.</summary>
+        public BoundingBox Boundary { get; set; }
+            = new BoundingBox(new Point2D(0, 0), new Point2D(0, 0));
+        /// <summary>Net definitions with pin positions.</summary>
+        public List<DsnNet> Nets { get; set; } = new();
+    }
+
+    /// <summary>Represents a parsed net.</summary>
+    public class DsnNet
+    {
+        /// <summary>Name of the net.</summary>
+        public string Name { get; set; } = string.Empty;
+        /// <summary>Absolute pin positions.</summary>
+        public List<Point2D> Pins { get; } = new();
+    }
+
+    internal record struct ComponentPlacement(string Image, double X, double Y, double Rotation);
+}
+

--- a/tests/Cli.Tests/DsnParserTests.cs
+++ b/tests/Cli.Tests/DsnParserTests.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using KRouter.Cli;
+using Xunit;
+
+namespace KRouter.Tests.Cli
+{
+    public class DsnParserTests
+    {
+        [Fact]
+        public void Parse_ExampleDsn_FindsNets()
+        {
+            var projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+            var dsnPath = Path.Combine(projectRoot, "samples", "boards", "example.dsn");
+            var dsn = File.ReadAllText(dsnPath);
+            var parser = new DsnParser();
+
+            var data = parser.Parse(dsn);
+
+            Assert.Contains(data.Nets, n => n.Name == "GND");
+            Assert.All(data.Nets, n => Assert.True(n.Pins.Count >= 2));
+        }
+    }
+}

--- a/tests/Cli.Tests/RouteServiceTests.cs
+++ b/tests/Cli.Tests/RouteServiceTests.cs
@@ -27,7 +27,12 @@ namespace KRouter.Tests.Cli
             var tempDir = Path.Combine(Path.GetTempPath(), "krouter_test", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(tempDir);
             var input = Path.Combine(tempDir, "board.dsn");
-            await File.WriteAllTextAsync(input, "(design (net N1) (net N2))");
+            var dsn = "(pcb test (parser) (resolution um 1) (unit um) " +
+                      "(structure (layer F.Cu) (boundary (path pcb 0 0 0 10 0 10 10 0 10))) " +
+                      "(library (image foo (pin pad 1 0 0))) " +
+                      "(placement (component foo (place A 0 0 front 0)) (component foo (place B 10 0 front 0))) " +
+                      "(network (net N1 (pins A-1 B-1))) )";
+            await File.WriteAllTextAsync(input, dsn);
             var output = Path.Combine(tempDir, "board.ses");
 
             var response = await service.RouteAsync(new RouteRequest

--- a/tests/Cli.Tests/SpectraSessionGeneratorTests.cs
+++ b/tests/Cli.Tests/SpectraSessionGeneratorTests.cs
@@ -21,6 +21,26 @@ namespace KRouter.Tests.Cli
             Assert.Contains("(place Q1 1259375 -946750 front 0)", ses);
             Assert.Contains("(net GND", ses);
         }
+
+        [Fact]
+        public void FromRouting_IncludesWireSegments()
+        {
+            var data = new DsnData { Resolution = 10, Layers = new System.Collections.Generic.List<string> { "F.Cu" } };
+            var net = new KRouter.Core.Routing.Net
+            {
+                Name = "N1",
+                Route = new KRouter.Core.Routing.Models.RoutingPath("N1")
+            };
+            net.Route!.Nodes.Add(new KRouter.Core.Routing.Models.RoutingNode(new KRouter.Core.Geometry.Point2D(0, 0), "F.Cu", 0));
+            net.Route.Nodes.Add(new KRouter.Core.Routing.Models.RoutingNode(new KRouter.Core.Geometry.Point2D(1000, 0), "F.Cu", 0));
+            var result = new KRouter.Core.Routing.RoutingResult();
+            result.RoutedNets.Add(net);
+
+            var ses = SpectraSessionGenerator.FromRouting(data, result, "design");
+
+            Assert.Contains("(wire", ses);
+            Assert.Contains("network_out", ses);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `DsnParser` to extract layers, boundary and net pin positions from DSN files
- generate SES from routing results with real wires and vias
- update route service to use DSN parser and new SES generator
- add unit tests for DSN parsing and SES generation

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a221a85e58832ca7d6c2bd6762b822